### PR TITLE
Move action text below header and above image for better presentation

### DIFF
--- a/docs/reports_actions.md
+++ b/docs/reports_actions.md
@@ -7,13 +7,13 @@ has_toc: true
 grand_parent: SmartClean Matrix
 nav_order: 2
 ---
-# What are Report Actions  
-
-![Matrix-WebReport(Actions)](https://www.smartclean.io/matrix/images/reportingServiceActions.png)
+# What are Report Actions
 
 Actions available on each report are shown as icon buttons in the same row as the report, under the Actions column.
 
-Common Report actions are as follows:
+![Matrix-WebReport(Actions)](https://www.smartclean.io/matrix/images/reportingServiceActions.png)
+
+Standard Report actions are as follows:
 1. **Execute Report:** 
    - Run the report to populate it with latest or custom data.
    - The button looks a triangle pointing right inside a circle (or a Play button)

--- a/docs/reports_edit.md
+++ b/docs/reports_edit.md
@@ -6,10 +6,9 @@ grand_parent: Reports
 nav_order: 3
 ---
 # How to Edit a Report
+Click on the Edit button (looks like an image of a box with a pencil) under Actions for a Report
 
 [comment]: <> (![Matrix-Edit Report]&#40;https://www.smartclean.io/matrix/images/reportsHome.png&#41;)
-
-Click on the Edit (looks like box with a pencil) button under Actions for a Report
 
 - A dialog box opens, with the current report details.
   - Press cancel or close after you are done viewing the details.

--- a/docs/reports_execute.md
+++ b/docs/reports_execute.md
@@ -6,10 +6,9 @@ grand_parent: Reports
 nav_order: 1
 ---
 # How to Execute a Report
+Click on the Execute button (looks like a triangle pointing right inside a circle) under Actions for a Report
 
 [comment]: <> (![Matrix-Execute Report]&#40;https://www.smartclean.io/matrix/images/reportsHome.png&#41;)
-
-Click on the Execute (looks like a triangle pointing right inside a circle) button under Actions for a Report
 
 - The report runs with the latest (or selected) data and a snapshot is saved.
 - This snapshot is available for viewing and sharing later.

--- a/docs/reports_view_share.md
+++ b/docs/reports_view_share.md
@@ -6,10 +6,9 @@ grand_parent: Reports
 nav_order: 2
 ---
 # How to View or Share a Report
+Click on the View button (looks like an eye image) under Actions for a Report
 
 ![Matrix-View / Share Report](https://www.smartclean.io/matrix/images/viewAndShareWebReportFinal.png)
-
-Click on the View (looks like an eye image) button under Actions for a Report
 
 - A dialog box opens, where you can specify the following:
   - *Select time range:* Choose desired time window (Start and End time) for data in the report.

--- a/docs/vcs.md
+++ b/docs/vcs.md
@@ -32,5 +32,5 @@ Some of our Solutions which generate Alerts are:
 5. [Consumable Monitoring](/vcs_cmd.html)
 6. [Bin Fill Level Sensing](/vcs_bin.html)
 
-## SuperSense Settings
-*Generation of Alerts for Solutions in a Location are subject to [Solution Settings](/vcs_settings.html) available in the SuperSense Control Centre*
+## Settings for SuperSense Alerts
+*Generation of Alerts for Solutions in a Location are subject to [Settings for SuperSense Alerts](/vcs_settings.html)*

--- a/docs/vcs_aq_settings.md
+++ b/docs/vcs_aq_settings.md
@@ -24,4 +24,4 @@ Configure per Device
     - **Criteria to create Alert:** When the number of air quality anomalies indicated by the Device in this duration has reached the limit (above Setting: Air quality anomalies limit).
     - **Outcome of Alert:** Notify intended users about Bad Air Quality in the location that the Device is assigned to.
 
-Go back to [Settings for SuperSense](/vcs_settings.html)
+Go back to [Settings for SuperSense Alerts](/vcs_settings.html)

--- a/docs/vcs_bin_settings.md
+++ b/docs/vcs_bin_settings.md
@@ -18,3 +18,5 @@ Configure per Device (Internal Setting)
     - **Description:** This threshold represents minimum area that is remaining in the Bin (i.e. how much empty it is.) 
     - **Criteria to create Alert:** When the area remaining value reported by the Bin Sensor reaches this minimum value.
     - **Outcome of Alert:** Notify intended users about the Bin (in a designated area) getting full.
+
+Go back to [Settings for SuperSense Alerts](/vcs_settings.html)

--- a/docs/vcs_cmd_settings.md
+++ b/docs/vcs_cmd_settings.md
@@ -18,3 +18,5 @@ Configure per Device (Internal Setting)
     - **Description:** This threshold represents the minimum fill level for the consumable being monitored. 
     - **Criteria to create Alert:** When the level of consumable being monitored reaches this minimum level. 
     - **Outcome of Alert:** Notify intended users about the Consumable (at a designated area) getting low.
+
+Go back to [Settings for SuperSense Alerts](/vcs_settings.html)

--- a/docs/vcs_fd_settings.md
+++ b/docs/vcs_fd_settings.md
@@ -18,3 +18,5 @@ Configure per Device (Internal Setting)
     - **Description:** This threshold represents the maximum limit for number of times bad feedback reason is reported to consider it for bad feedback Alert. 
     - **Criteria to create Alert:** When the number of times a bad feedback reason reported reaches this limit (one or more reasons), they get included in the bad feedback alert. 
     - **Outcome of Alert:** Notify intended users about the bad feedback reported in a location.
+
+Go back to [Settings for SuperSense Alerts](/vcs_settings.html)

--- a/docs/vcs_pc_settings.md
+++ b/docs/vcs_pc_settings.md
@@ -19,4 +19,4 @@ Configure per Device
     - **Criteria to create Alert:** When total count of people that have entered the location reaches this threshold
     - **Outcome of Alert:** Notify intended users about high usage at the location being monitored.
 
-Go back to [Settings for SuperSense](/vcs_settings.html)
+Go back to [Settings for SuperSense Alerts](/vcs_settings.html)

--- a/docs/vcs_settings.md
+++ b/docs/vcs_settings.md
@@ -3,7 +3,7 @@ layout: default
 title: SuperSense Settings
 parent: SuperSense
 has_children: true
-has_toc: true
+has_toc: false
 grand_parent: SmartClean Matrix
 nav_order: 3
 ---

--- a/docs/vcs_settings.md
+++ b/docs/vcs_settings.md
@@ -2,6 +2,8 @@
 layout: default
 title: SuperSense Settings
 parent: SuperSense
+has_children: true
+has_toc: true
 grand_parent: SmartClean Matrix
 nav_order: 3
 ---

--- a/docs/vcs_solutions.md
+++ b/docs/vcs_solutions.md
@@ -28,8 +28,10 @@ In order to make your facility management requirement smart with our platform, t
 
 4. Done! Your Facility Management need has just been made smarter with our Solution.
 
-As SuperSense detects desired events for this Solution in this Location, Alerts will be generated based on default settings.
-You may view these in your [SmartClean Matrix Application](/index.html)
+As SuperSense detects desired events for this Solution in this Location, 
+Alerts will be generated based on default values of [SuperSense Settings](/vcs_settings.html)
+
+You may view these Alerts in your [SmartClean Matrix Application](/index.html)
 
 Some of our solutions which generate Alerts are:
 1. [Air Quality Monitoring](/vcs_aq.html)

--- a/docs/vcs_solutions.md
+++ b/docs/vcs_solutions.md
@@ -3,6 +3,7 @@ layout: default
 title: SuperSense Solutions
 parent: SuperSense
 has_children: true
+has_toc: true
 grand_parent: SmartClean Matrix
 nav_order: 2
 ---
@@ -32,11 +33,3 @@ As SuperSense detects desired events for this Solution in this Location,
 Alerts will be generated based on default values of [SuperSense Settings](/vcs_settings.html)
 
 You may view these Alerts in your [SmartClean Matrix Application](/index.html)
-
-Some of our solutions which generate Alerts are:
-1. [Air Quality Monitoring](/vcs_aq.html)
-2. [Usage Monitoring](/vcs_pc.html)
-3. [Spill Detection](/vcs_wd.html)
-4. [Bad Feedback Reporting](/vcs_fd.html)
-5. [Consumable Monitoring](/vcs_cmd.html)
-6. [Bin Fill Level Sensing](/vcs_bin.html)


### PR DESCRIPTION
**For sub pages in Report Actions**
- Move the action text up, below the heading and above the image for better presentation.
- Improve language of the action text
---
**For SuperSense subpages:**
- Add link to Settings page, improve language of this statement
---
**For SuperSense Settings:**
- Allow navigation to child pages (enable has_children)
- In child pages: Link back to the parent Settings page at bottom.