### PR TITLE
Add release notes, improve 1 comment on AQ data attribute

### DIFF
--- a/docs/realsense_sensor_data_aq.md
+++ b/docs/realsense_sensor_data_aq.md
@@ -16,7 +16,7 @@ Device slot types applicable:
 Format of attribute: *"v"* in the general data format:
 ```json
 {
-  "amm": <number>, // Ammonia channel reading in parts per million (ppm).
+  "amm": <number>, // Ammonia channel reading.
   "aqi": <number>, // Air Quality Index (number between 1 - 500), only present for ODRDTR_BATT_V1
   "rssi": "<number>",  // Received signal strength indicator
   "amm_expected": <number>, // Predicted value for the ammonia channel (used to generate "amm_zscore")

--- a/docs/releaseNotesMain-2022-04-16.md
+++ b/docs/releaseNotesMain-2022-04-16.md
@@ -1,0 +1,32 @@
+---
+layout: default
+title: 2022-04-16
+parent: Release Notes
+has_children: false
+has_toc: false
+nav_order: 7
+---
+
+# Release notes for 2022-04-16
+
+Bugfix
+{: .label .label-red }
+- Housekeeping app now shows the time when an incident is due (in addition to the date).
+
+Enhancement
+{: .label .label-green }
+- An "overdue" label will show on incidents that are past their due time. 
+
+Feature
+{: .label .label-blue }
+- Workorders dashboard now allows you to copy shifts created in past as new shifts in the future.
+
+Feature
+{: .label .label-blue }
+- A new setting now allows staff to start ad hoc shifts (if the shift was not planned or the availabilities not defined)
+- A default time of 8 hours is then used to start this unplanned shift.
+
+Pre-release
+{: .label .label-purple }
+- Defects reporting through standard QR codes is now in pre-release. 
+- This feature will allow properties to configure their defects and user feedbacks through QR codes


### PR DESCRIPTION
1. release notes for 16th April added.
2. Improvement to comment in AQ data attribute: Truncate the parts per million in the comment as it depends on whether AQLite or standard AQ.