### PR TITLE
Increase screenshot size (appears very small in hosted page)

### DIFF
--- a/docs/releaseNotesMain-2022-05-07.md
+++ b/docs/releaseNotesMain-2022-05-07.md
@@ -25,4 +25,4 @@ multiple table views to highlight their averages and trends.
 
 #### 1. Audit tally report
 
-<img alt="Audits tally report" src="https://www.smartclean.io/matrix/images/auditsTallyReportExample1.png" width="270"/>
+<img alt="Audits tally report" src="https://www.smartclean.io/matrix/images/auditsTallyReportExample1.png" width="480"/>


### PR DESCRIPTION
Screenshot for audit tally report at the following page (Link:
https://www.docs.smartclean.io/releaseNotesMain-2022-05-07.html ) appears very small, the width property of the image has been increased from 270 to 480 (height will auto-adjust according to width)