### PR TITLE
Fix for a format issue, proposed addition and minor enhancements.

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -2,7 +2,7 @@
 layout: default
 title: Integrations
 has_children: true
-has_toc: true
+has_toc: false
 nav_order: 9
 ---
 

--- a/docs/integrations_db.md
+++ b/docs/integrations_db.md
@@ -35,5 +35,3 @@ Our Solution:
       (Based on what we use for our platform)
    3. Database connection details.
    4. Follow up, in case you want us to write data to a PostgreSQL database that hosted by you, instead of us.
-
----

--- a/docs/integrations_push.md
+++ b/docs/integrations_push.md
@@ -59,5 +59,3 @@ An overview of these are given in the below sections.
 ## Difference between Matrix events push and Sensor data push:
 1. For the user of these two services, both behave the same, i.e. both send data to a web service (HTTPS endpoint)
 2. Since sensor data can be quite voluminous as compared to Matrix events, sensor data push is activated separately from other events.
-
----

--- a/docs/integrations_sdk.md
+++ b/docs/integrations_sdk.md
@@ -38,4 +38,3 @@ Outcome:
 - Useful for making repeated web requests to our services within your programming environment conveniently.
 - Each SDK is optimised for use in its respective programming environment
 - Build or enhance your programs by using SDK.
----

--- a/docs/integrations_sdk.md
+++ b/docs/integrations_sdk.md
@@ -22,6 +22,8 @@ We currently have an SDK for following languages available as a release in Githu
 1. For _Python_, [visit the Github page here](https://github.com/hello-error/PythonSDK)
 2. For _Java_, [visit the Github page here](https://github.com/smartclean/smartclean-sdk-java-builds)
 
+An SDK for Golang is under development. For early access, please contact us.
+
 Steps for use:
 Generally the SDK will have the below steps for usage:
 - Download and install the SDK into your application (or just add the SDK folder in your program folder).

--- a/docs/integrations_web.md
+++ b/docs/integrations_web.md
@@ -34,5 +34,3 @@ Our Solution:
     4. Create an incident for a location.
    
 Note: These examples are described in the API documentation (point 3, above)
-
----


### PR DESCRIPTION
Updates:
1. Fix last line showing as heading.
2. Add note about SDK for Golang.
3. Remove table of contents from main page (reason below)
4. Remove section break at end of the other sub pages of integrations also.
 
**Reason for point 3:**
Links to sub pages are already provided in this page.
If table of contents is enabled, it appears to duplicate the links already provided.